### PR TITLE
demo: GHA secret scanner runs after push (PoC, do not merge)

### DIFF
--- a/src/main/java/uk/gov/hmcts/cp/DemoSecretScanTrigger.java
+++ b/src/main/java/uk/gov/hmcts/cp/DemoSecretScanTrigger.java
@@ -1,0 +1,24 @@
+package uk.gov.hmcts.cp;
+
+/*
+ * INTENTIONAL DEMO — synthetic value, NOT a real credential.
+ *
+ * Purpose: demonstrate that the secrets-scanner GitHub Actions workflow
+ * (.github/workflows/secrets-scanner.yml) only runs AFTER a developer pushes
+ * the commit to origin. By the time the workflow flags the leak, the blob
+ * is already on the remote and reachable via refs/pull/N/head forever.
+ *
+ * A pre-commit hook running gitleaks (or a husky/git-pre-commit-hook
+ * equivalent) on the developer's machine would have caught this BEFORE
+ * the push, keeping the secret out of the repo's object database entirely.
+ *
+ * Do NOT merge this file. Do NOT use this value anywhere.
+ */
+public final class DemoSecretScanTrigger {
+
+    private static final String apiKey = "Zk3pX9mQ7vR2tN8jL5wH4yC1bF6gD0sA8eU2iO7rT4nM6kP9xV3zB1qY5wE8hJ2";
+
+    private DemoSecretScanTrigger() {
+        // utility class — not instantiable
+    }
+}


### PR DESCRIPTION
## ⚠️ DO NOT MERGE — proof-of-concept demonstration

This PR exists to demonstrate a single point: **the `secrets-scanner` GitHub Actions workflow runs after the developer has already pushed to `origin`.** By the time it flags a leaked secret, the offending blob is already on the remote and reachable via `refs/pull/N/head` forever — even after this PR is closed and the branch deleted.

### What this PR does

Adds one Java file containing a synthetic, high-entropy string that triggers gitleaks' `generic-api-key` rule:

```java
private static final String apiKey = "Zk3pX9mQ7vR2tN8jL5wH4yC1bF6gD0sA8eU2iO7rT4nM6kP9xV3zB1qY5wE8hJ2";
```

The value is **synthetic** — it matches no real provider format, is not a credential to anything, and has been generated specifically for this demo.

### What you should see when CI runs

- ✅ `Analyze (java)`, `CodeQL`, `pmd-analysis` — pass (the file compiles and has no real code-quality issues)
- ❌ **`scan` (the `hmcts/secrets-scanner@main` action wrapping gitleaks)** — fails on the new file

### The lesson

If a `pre-commit` hook running gitleaks had been installed on the developer's workstation, this push would have been blocked locally. The secret would never have left the laptop. Today, the chain of events is:

1. Developer runs `git commit` — no check.
2. Developer runs `git push` — blob goes to origin.
3. Developer runs `gh pr create` — PR opens, GHA fires, **blob is already on origin**.
4. Even if we now close this PR and delete the branch, the blob stays in the GitHub-side `refs/pull/N/head` ref permanently.

Steps 1–3 are seconds apart. The window between "secret is on origin" and "scanner detects it" is unavoidable as long as scanning happens on the GitHub side rather than in the developer's local git workflow.

### Cleanup

This PR will be closed unmerged once the failing `scan` check is visible. The branch will be deleted. The synthetic blob will, of course, **remain on origin forever** — which is the entire point of the demonstration.