### PR TITLE
LPT-2370 - Tag SJP error logs with ALERT_PATTERN

### DIFF
--- a/src/main/java/uk/gov/hmcts/cp/config/AppConstant.java
+++ b/src/main/java/uk/gov/hmcts/cp/config/AppConstant.java
@@ -4,4 +4,7 @@ public class AppConstant {
     private AppConstant(){}
 
     public static final String CJSCPPUID = "CJSCPPUID";
+
+    /** Log marker for alerting on publish failures; used across both the standard and SJP flows. */
+    public static final String ALERT_PATTERN = "PUBLISHING_FAILED";
 }

--- a/src/main/java/uk/gov/hmcts/cp/services/CaTHService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/CaTHService.java
@@ -22,7 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
-import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/uk/gov/hmcts/cp/services/CourtListPdfHelper.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/CourtListPdfHelper.java
@@ -11,7 +11,7 @@ import uk.gov.hmcts.cp.taskmanager.domain.converter.JsonObjectConverter;
 import java.io.IOException;
 import java.util.UUID;
 
-import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 
 /**
  * Helper class for PDF generation operations related to court list publishing.

--- a/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
@@ -22,7 +22,7 @@ import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import java.util.UUID;
 
-import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 
 /**
  * Validates and accepts SJP publish requests (full/delta, public/press); the transform, blob

--- a/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
@@ -22,6 +22,8 @@ import java.time.format.DateTimeParseException;
 import java.util.Optional;
 import java.util.UUID;
 
+import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+
 /**
  * Validates and accepts SJP publish requests (full/delta, public/press); the transform, blob
  * upload, and CaTH send are queued as an async job ({@link SjpTaskTriggerService} /
@@ -107,7 +109,8 @@ public class SjpCourtListPublishService {
                     courtListId, listType);
             return SjpPublishResult.accepted(listType, "SJP court list publish request accepted for processing");
         } catch (Exception e) {
-            LOG.error("Failed to queue SJP court list for publishing: {}", Encode.forJava(e.getMessage()), e);
+            LOG.error("Error {} failed to queue SJP court list for publishing: {}",
+                    ALERT_PATTERN, Encode.forJava(e.getMessage()), e);
             return SjpPublishResult.failed(listType, "Failed to queue SJP court list for publishing: " + e.getMessage());
         }
     }

--- a/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpTaskTriggerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpTaskTriggerService.java
@@ -16,7 +16,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import static java.time.ZonedDateTime.now;
-import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 
 /**

--- a/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpTaskTriggerService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpTaskTriggerService.java
@@ -16,6 +16,7 @@ import java.time.LocalDate;
 import java.util.UUID;
 
 import static java.time.ZonedDateTime.now;
+import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 
 /**
@@ -70,7 +71,8 @@ public class SjpTaskTriggerService {
             executionService.executeWith(executionInfo);
             LOG.atInfo().log("SJP publish task triggered successfully for sjpListId: {}", sjpListId);
         } catch (Exception e) {
-            LOG.atError().log("Failed to execute SJP publish task via ExecutionService: {}", Encode.forJava(e.getMessage()), e);
+            LOG.atError().log("Error {} failed to execute SJP publish task via ExecutionService: {}",
+                    ALERT_PATTERN, Encode.forJava(e.getMessage()), e);
             throw new RuntimeException("Failed to trigger SJP publish task: " + e.getMessage(), e);
         }
     }

--- a/src/main/java/uk/gov/hmcts/cp/task/CourtListPublishAndPDFGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/task/CourtListPublishAndPDFGenerationTask.java
@@ -19,6 +19,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.COMPLETED;
 
@@ -28,8 +29,6 @@ import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.COMPLETED;
 public class CourtListPublishAndPDFGenerationTask implements ExecutableTask {
 
     private static final Logger logger = LoggerFactory.getLogger(CourtListPublishAndPDFGenerationTask.class);
-
-    public static final String ALERT_PATTERN = "PUBLISHING_FAILED";
 
     private final CourtListStatusUpdater statusUpdater;
     private final CourtListQueryService courtListQueryService;

--- a/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
@@ -25,6 +25,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
 
+import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.COMPLETED;
 
@@ -91,7 +92,7 @@ public class SjpPublishTask implements ExecutableTask {
                 publish(courtListId, jobData);
             }
         } catch (Exception e) {
-            logger.error("Error publishing SJP court list for courtListId: {}", courtListId, e);
+            logger.error("Error {} publishing SJP court list for courtListId: {}", ALERT_PATTERN, courtListId, e);
             if (courtListId != null) {
                 statusUpdater.markPublishFailed(courtListId, e);
             }
@@ -150,7 +151,8 @@ public class SjpPublishTask implements ExecutableTask {
             statusUpdater.markPublishSuccessful(courtListId);
         } else {
             RuntimeException cathFailure = new RuntimeException("CaTH returned status " + status);
-            logger.error("CaTH publish failed for courtListId: {}, listType: {}, status: {}", courtListId, listType, status, cathFailure);
+            logger.error("Error {} CaTH publish failed for courtListId: {}, listType: {}, status: {}",
+                    ALERT_PATTERN, courtListId, listType, status, cathFailure);
             statusUpdater.markPublishFailed(courtListId, cathFailure);
         }
     }
@@ -161,7 +163,7 @@ public class SjpPublishTask implements ExecutableTask {
                     try {
                         blobService.uploadJson(payload, CaTHService.buildBlobName(courtListId));
                     } catch (Exception e) {
-                        logger.error("Error uploading SJP payload to blob storage, continuing with publish", e);
+                        logger.error("Error {} uploading SJP payload to blob storage, continuing with publish", ALERT_PATTERN, e);
                     }
                 },
                 () -> logger.debug("Azure Blob Service not available, skipping SJP payload upload")

--- a/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
@@ -25,7 +25,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 import java.util.UUID;
 
-import static uk.gov.hmcts.cp.task.CourtListPublishAndPDFGenerationTask.ALERT_PATTERN;
+import static uk.gov.hmcts.cp.config.AppConstant.ALERT_PATTERN;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionInfo.executionInfo;
 import static uk.gov.hmcts.cp.taskmanager.domain.ExecutionStatus.COMPLETED;
 


### PR DESCRIPTION
## Summary
- Tag every error-level log in the SJP publish pipeline (`SjpPublishTask`, `SjpCourtListPublishService`, `SjpTaskTriggerService`) with the same `ALERT_PATTERN` marker already used by the standard court-list publish flow, so alerting/monitoring picks up SJP failures the same way.
- Move `ALERT_PATTERN` out of `CourtListPublishAndPDFGenerationTask` and into `AppConstant`, since it's now shared by both flows and keeping it on a single task class was misleading. All six consumers updated to import from `AppConstant`.

## Test plan
- [x] `./gradlew compileJava` - clean
- [x] `./gradlew test` - full unit suite green