### PR TITLE
LPT-2370 - Log listType/language and mapping decisions for both flows

### DIFF
--- a/src/main/java/uk/gov/hmcts/cp/controllers/CourtListPublishController.java
+++ b/src/main/java/uk/gov/hmcts/cp/controllers/CourtListPublishController.java
@@ -203,7 +203,8 @@ public class CourtListPublishController implements CourtListPublishApi {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "listPayload is required");
         }
 
-        LOG.atInfo().log("SJP court list publish request for listType: {}", request.getListType());
+        LOG.atInfo().log("SJP court list publish request for listType: {}, language: {}",
+                request.getListType(), request.getLanguage());
 
         SjpPublishResult result = sjpCourtListPublishService.publishSjpCourtList(
                 request.getListType(),

--- a/src/main/java/uk/gov/hmcts/cp/services/CaTHService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/CaTHService.java
@@ -47,7 +47,8 @@ public class CaTHService {
     public void sendCourtListToCaTH(CourtListDocument courtListDocument, final CourtListType courtListType, final LocalDate publishDate,
                                     String courtIdNumeric, Boolean isWelsh, UUID courtListId) {
         try {
-            log.info("Sending court list document to CaTH endpoint");
+            final String language = Boolean.TRUE.equals(isWelsh) ? "WELSH" : "ENGLISH";
+            log.info("Sending court list document to CaTH endpoint, courtListType={}, language={}", courtListType, language);
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -62,8 +63,10 @@ public class CaTHService {
                 throw new IllegalStateException("Unsupported court list type "+courtListType);
             }
 
+            log.info("CaTH list type mapping resolved: courtListType={} -> cathListType={}, sensitivity={}",
+                    courtListType, cathListInfo.cathCourtListType(), cathListInfo.sensitivity());
+
             final Instant now = Instant.now();
-            final String language = Boolean.TRUE.equals(isWelsh) ? "WELSH" : "ENGLISH";
             final DtsMeta dtsMeta = DtsMeta.builder()
                     .provenance("COMMON_PLATFORM")
                     .type("LIST")
@@ -82,7 +85,8 @@ public class CaTHService {
 
             final Integer res = caTHPublisher.publish(payload, dtsMeta);
 
-            log.info("Successfully sent court list document to CaTH. Response status: {}", res);
+            log.info("Successfully sent court list document to CaTH, courtListType={}, language={}, status={}",
+                    courtListType, language, res);
         } catch (Exception e) {
             log.error("Error {} sending court list document to CaTH endpoint: {}", ALERT_PATTERN, e.getMessage(), e);
             throw new RuntimeException("Failed to send court list document to CaTH: " + e.getMessage(), e);

--- a/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
+++ b/src/main/java/uk/gov/hmcts/cp/services/sjp/SjpCourtListPublishService.java
@@ -67,7 +67,7 @@ public class SjpCourtListPublishService {
             String language,
             String requestType,
             Object listPayload) {
-        LOG.info("SJP court list publish request for listType: {}", listType);
+        LOG.info("SJP court list publish request for listType: {}, language: {}", listType, language);
 
         if (!cathPublishingEnabled) {
             LOG.debug("CaTH publishing is disabled (CATH_PUBLISHING_ENABLED=false), skipping SJP CaTH send");
@@ -99,14 +99,16 @@ public class SjpCourtListPublishService {
             LocalDate publishDate = deriveDate(payload.getGeneratedDateAndTime());
             String lang = resolveLanguage(language, payload);
             CourtListType fusedListType = SjpStatusListTypeMapper.toCourtListType(listType, lang);
+            LOG.info("SJP list type mapping resolved: listType={}, language={} -> fused courtListType={}",
+                    listType, lang, fusedListType);
             UUID courtListId = findOrCreateCourtListId(fusedListType, publishDate);
 
             String payloadJson = OBJECT_MAPPER.writeValueAsString(payload);
             sjpTaskTriggerService.triggerSjpPublishTask(
                     courtListId, courtIdNumeric, listType, publishDate, language, requestType, payloadJson);
 
-            LOG.info("SJP court list publish request queued, courtListId={}, listType={}",
-                    courtListId, listType);
+            LOG.info("SJP court list publish request queued, courtListId={}, listType={}, language={}, courtListType={}",
+                    courtListId, listType, lang, fusedListType);
             return SjpPublishResult.accepted(listType, "SJP court list publish request accepted for processing");
         } catch (Exception e) {
             LOG.error("Error {} failed to queue SJP court list for publishing: {}",

--- a/src/main/java/uk/gov/hmcts/cp/task/CourtListPublishAndPDFGenerationTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/task/CourtListPublishAndPDFGenerationTask.java
@@ -149,10 +149,13 @@ public class CourtListPublishAndPDFGenerationTask implements ExecutableTask {
         }
         try {
             var courtListDocument = courtListQueryService.buildCourtListDocumentFromPayload(payload, listId);
-            logger.info("Sending transformed court list document to CaTH endpoint");
+            String language = Boolean.TRUE.equals(payload.getIsWelsh()) ? "WELSH" : "ENGLISH";
+            logger.info("Sending transformed court list document to CaTH endpoint, courtListType={}, language={}",
+                    listId, language);
             cathService.sendCourtListToCaTH(courtListDocument, listId, publishDate,
                     payload.getCourtIdNumeric(), payload.getIsWelsh(), courtListId);
-            logger.info("Successfully sent court list document to CaTH endpoint");
+            logger.info("Successfully sent court list document to CaTH endpoint, courtListType={}, language={}",
+                    listId, language);
         } catch (Exception e) {
             logger.error("Error {} building document or sending court list to CaTH", ALERT_PATTERN, e);
             throw new RuntimeException("Failed to send court list to CaTH: " + e.getMessage(), e);

--- a/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
+++ b/src/main/java/uk/gov/hmcts/cp/task/SjpPublishTask.java
@@ -143,6 +143,8 @@ public class SjpPublishTask implements ExecutableTask {
         uploadPayloadToBlob(transformedPayload, courtListId);
 
         DtsMeta meta = buildDtsMeta(cathListType, sensitivity, lang, requestType, payload.getCourtIdNumeric());
+        logger.info("Sending SJP court list to CaTH, courtListId={}, cathListType={}, language={}, sensitivity={}",
+                courtListId, cathListType, lang, sensitivity);
         int status = courtListPublisher.publish(transformedPayload, meta);
         logger.info("SJP court list published to CaTH, courtListId={}, listType={}, language={}, status={}",
                 courtListId, listType, lang, status);


### PR DESCRIPTION
## Summary
- **Standard flow** (`CourtListPublishAndPDFGenerationTask`, `CaTHService`): the "sending"/"sent" CaTH logs now include `courtListType` and the derived `language`; added a log for the `COURT_LIST_MAPPINGS` lookup result (`courtListType` -> `cathListType`/`sensitivity`).
- **SJP flow** (controller, `SjpCourtListPublishService`, `SjpPublishTask`): the initial publish-request logs now include `language` alongside `listType` (previously missing); added a log for `SjpStatusListTypeMapper`'s resolution (`listType`/`language` -> fused `courtListType`); added a log showing exactly what's being sent to CaTH (`cathListType`, `language`, `sensitivity`) right before the publish call.

## Test plan
- [x] `./gradlew compileJava` - clean
- [x] `./gradlew test` - full unit suite green
- [x] Confirmed no test asserts on the changed log message strings